### PR TITLE
feat: add ability to use env-vars with a python-like syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,35 @@
-pytest-env
-=================
+# pytest-env
 
 This is a py.test plugin that enables you to set environment variables in the pytest.ini file.
 
-Installation
-------------
+## Installation
 
-Install with pip::
+Install with pip:
 
     pip install pytest-env
 
-Uninstall with pip::
+Uninstall with pip:
 
     pip uninstall pytest-env
 
-Usage
------
+## Usage
 
-In your pytest.ini file add a key value pair with `env` as the key and the environment variables as a line 
-separated list of `KEY=VALUE` entries.  The defined variables will be added to the environment before any tests are run:
+In your pytest.ini file add a key value pair with `env` as the key and the environment variables as a line separated list of `KEY=VALUE` entries.  The defined variables will be added to the environment before any tests are run:
 
     [pytest]
-    env = 
+    env =
         HOME=~/tmp
         RUN_ENV=test
 
 You can use `D:` (default) as prefix if you don't want to override existing environment variables:
 
-
     [pytest]
-    env = 
+    env =
         D:HOME=~/tmp
         D:RUN_ENV=test
 
+Lastly, you can use existing environment variables using a python-like format:
+
+    [pytest]
+    env =
+        RUN_PATH=/run/path/{USER}

--- a/pytest_env/plugin.py
+++ b/pytest_env/plugin.py
@@ -1,27 +1,43 @@
-import os
 
+"""Adopt environment section in pytest configuration files."""
+
+import os
 import pytest
 
 
 def pytest_addoption(parser):
-    parser.addini("env",
-                  type="linelist",
-                  help="a line separated list of environment variables of the form NAME=VALUE)",
-                  default=[])
+    """Add section to configuration files."""
+    help_msg = (
+        "a line separated list of environment variables "
+        "of the form NAME=VALUE."
+        )
+
+    parser.addini(
+        "env",
+        type="linelist",
+        help=help_msg,
+        default=[]
+        )
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_load_initial_conftests(args, early_config, parser):
+    """Load environment variables from configuration files."""
     for e in early_config.getini("env"):
         part = e.partition("=")
         key = part[0].strip()
         value = part[2].strip()
 
-        # use D: as a way to designate a default value 
-        # that will only override env variables if they 
+        # Replace environment variables in value. for instance:
+        # TEST_DIR={USER}/repo_test_dir.
+        value = value.format(**os.environ)
+
+        # use D: as a way to designate a default value
+        # that will only override env variables if they
         # do not exist already
         dkey = key.split("D:")
         default_val = False
+
         if len(dkey) == 2:
             key = dkey[1]
             default_val = True

--- a/pytest_env/plugin.py
+++ b/pytest_env/plugin.py
@@ -1,4 +1,3 @@
-
 """Adopt environment section in pytest configuration files."""
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
+
+"""pytest-env setup module."""
+
 from setuptools import setup
 
-description = 'py.test plugin that allows you to add environment variables.'
+DESCRIPTION = 'py.test plugin that allows you to add environment variables.'
 
 setup(
     name='pytest-env',
-    description=description,
-    long_description=description,
-    version='0.6.1',
+    description=DESCRIPTION,
+    long_description=DESCRIPTION,
+    version='0.6.2',
     author='dev@mobile-dynasty.com',
     author_email='dev@mobile-dynasty.com',
     url='https://github.com/MobileDynasty/pytest-env',
@@ -23,5 +26,5 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
-    ]
-)
+        ]
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-
 """pytest-env setup module."""
 
 from setuptools import setup
@@ -26,5 +25,5 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
-        ]
-    )
+    ]
+)


### PR DESCRIPTION
This pull request enables the use environment variables in the test env configuration using:

    @pytest.hookimpl(tryfirst=True)
    def pytest_load_initial_conftests(args, early_config, parser):
        ...
        # Replace environment variables in value. for instance:
        # RUN_PATH=/run/path/{USER}
        value = value.format(**os.environ)
        ...

This functionality has been documented in the `README.md`. Additionally, I added some simple docs and pep8 styling changes. I think this change is worth increasing the version to 0.6.2, I updated the `setup.py` accordingly.

I also changed the `RST` format to `markdown` since the file was called `README.md`.